### PR TITLE
add check to forbid variable declarations directly in state struct

### DIFF
--- a/src/lib/check_variables.cpp
+++ b/src/lib/check_variables.cpp
@@ -112,6 +112,16 @@ namespace contractverify
             return false;
         }
 
+        // Variables directly in the state struct must be in a nested struct (e.g., StateData)
+        if (!analysisData.scopeStack.empty()
+            && (analysisData.scopeStack.top() == ScopeSpec::STRUCT || analysisData.scopeStack.top() == ScopeSpec::CLASS)
+            && analysisData.scopeNames.size() == 1
+            && analysisData.scopeNames[0] == stateStructName)
+        {
+            std::cout << "[ ERROR ] Variable declarations are not allowed directly in the state struct. Use the nested struct StateData for state variables." << std::endl;
+            return false;
+        }
+
         if (var.isTemplated())
         {
             RETURN_IF_FALSE(checkTemplSpec(var.templateSpecification().value(), stateStructName, analysisData));

--- a/test/contract_verify_test.cpp
+++ b/test/contract_verify_test.cpp
@@ -183,6 +183,10 @@ namespace contractverify
             "test_ok_input_output_6.h",
             "InputOutputTypes6"
         },
+        {
+            "test_ok_state_data.h",
+            "StateData"
+        },
     };
 
     FailureTestInfo failureTestInfos[] = {
@@ -505,6 +509,11 @@ namespace contractverify
             "test_fail_input_output_8.h",
             "[ ERROR ] Pointers are not allowed.\n",
             "InputOutputTypes8"
+        },
+        {
+            "test_fail_state_struct_variable.h",
+            "[ ERROR ] Variable declarations are not allowed directly in the state struct. Use the nested struct StateData for state variables.\n",
+            "StateStructVariable"
         },
     };
 

--- a/test/testfiles/test_fail_allocation_new.h
+++ b/test/testfiles/test_fail_allocation_new.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    auto dummy = new DummyClass();
+    struct StateData
+    {
+        auto dummy = new DummyClass();
+    };
 };

--- a/test/testfiles/test_fail_array_declaration.h
+++ b/test/testfiles/test_fail_array_declaration.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int forbiddenArray[20];
+    struct StateData
+    {
+        int forbiddenArray[20];
+    };
 };

--- a/test/testfiles/test_fail_array_indexing.h
+++ b/test/testfiles/test_fail_array_indexing.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int dummy = someGlobalArray[0];
+    struct StateData
+    {
+        int dummy = someGlobalArray[0];
+    };
 };

--- a/test/testfiles/test_fail_char_literal.h
+++ b/test/testfiles/test_fail_char_literal.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    auto forbiddenChar = 'c';
+    struct StateData
+    {
+        auto forbiddenChar = 'c';
+    };
 };

--- a/test/testfiles/test_fail_const_cast.h
+++ b/test/testfiles/test_fail_const_cast.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int& dummy = const_cast<int&>(someConstIntVar);
+    struct StateData
+    {
+        int& dummy = const_cast<int&>(someConstIntVar);
+    };
 };

--- a/test/testfiles/test_fail_dereferencing_arrow.h
+++ b/test/testfiles/test_fail_dereferencing_arrow.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int dummy = someGlobalPtr->giveInt();
+    struct StateData
+    {
+        int dummy = someGlobalPtr->giveInt();
+    };
 };

--- a/test/testfiles/test_fail_dereferencing_arrow_star.h
+++ b/test/testfiles/test_fail_dereferencing_arrow_star.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int dummy = someGlobalPtr->*giveInt();
+    struct StateData
+    {
+        int dummy = someGlobalPtr->*giveInt();
+    };
 };

--- a/test/testfiles/test_fail_div.h
+++ b/test/testfiles/test_fail_div.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int dummy = 3452/43;
+    struct StateData
+    {
+        int dummy = 3452/43;
+    };
 };

--- a/test/testfiles/test_fail_mod.h
+++ b/test/testfiles/test_fail_mod.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int dummy = 8483%7;
+    struct StateData
+    {
+        int dummy = 8483%7;
+    };
 };

--- a/test/testfiles/test_fail_name_var.h
+++ b/test/testfiles/test_fail_name_var.h
@@ -2,5 +2,8 @@ using namespace QPI;
 
 struct TESTCON : public ContractBase
 {
-    int __forbiddenName;
+    struct StateData
+    {
+        int __forbiddenName;
+    };
 };

--- a/test/testfiles/test_fail_pointer_declaration.h
+++ b/test/testfiles/test_fail_pointer_declaration.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int* forbiddenPtr;
+    struct StateData
+    {
+        int* forbiddenPtr;
+    };
 };

--- a/test/testfiles/test_fail_pointer_dereferencing.h
+++ b/test/testfiles/test_fail_pointer_dereferencing.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int dummy = *someGlobalIntPointer;
+    struct StateData
+    {
+        int dummy = *someGlobalIntPointer;
+    };
 };

--- a/test/testfiles/test_fail_restricted_function_call.h
+++ b/test/testfiles/test_fail_restricted_function_call.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int dummy = __restrictedFunction(43);
+    struct StateData
+    {
+        int dummy = __restrictedFunction(43);
+    };
 };

--- a/test/testfiles/test_fail_restricted_variable.h
+++ b/test/testfiles/test_fail_restricted_variable.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int dummy = __restrictedVariable;
+    struct StateData
+    {
+        int dummy = __restrictedVariable;
+    };
 };

--- a/test/testfiles/test_fail_scope_resolution_variable.h
+++ b/test/testfiles/test_fail_scope_resolution_variable.h
@@ -1,4 +1,7 @@
 struct TESTCON : public ContractBase
 {
-    myNumbers::MyInt i;
+    struct StateData
+    {
+        myNumbers::MyInt i;
+    };
 };

--- a/test/testfiles/test_fail_state_struct_variable.h
+++ b/test/testfiles/test_fail_state_struct_variable.h
@@ -1,9 +1,5 @@
 using namespace QPI;
-
 struct TESTCON : public ContractBase
 {
-    struct StateData
-    {
-        char c = 'a';
-    };
+    uint64 someVar;
 };

--- a/test/testfiles/test_fail_string_literal.h
+++ b/test/testfiles/test_fail_string_literal.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    auto forbiddenString = "I am a string literal";
+    struct StateData
+    {
+        auto forbiddenString = "I am a string literal";
+    };
 };

--- a/test/testfiles/test_fail_type_float.h
+++ b/test/testfiles/test_fail_type_float.h
@@ -2,5 +2,8 @@ using namespace QPI;
 
 struct TESTCON : public ContractBase
 {
-    float f;
+    struct StateData
+    {
+        float f;
+    };
 };

--- a/test/testfiles/test_fail_variable_referencing.h
+++ b/test/testfiles/test_fail_variable_referencing.h
@@ -3,6 +3,9 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int dummy = 42;
-    auto addr = &dummy;
+    struct StateData
+    {
+        int dummy = 42;
+        auto addr = &dummy;
+    };
 };

--- a/test/testfiles/test_fail_variadic_sizeof.h
+++ b/test/testfiles/test_fail_variadic_sizeof.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    auto dummy = sizeof...(somePack);
+    struct StateData
+    {
+        auto dummy = sizeof...(somePack);
+    };
 };

--- a/test/testfiles/test_ok.h
+++ b/test/testfiles/test_ok.h
@@ -101,24 +101,27 @@ struct QUTIL2
 struct QUTIL : public ContractBase
 {
 private:
-    // registers, logger and other buffer
-    sint32 _i0, _i1, _i2, _i3;
-    sint64 _i64_0, _i64_1, _i64_2, _i64_3;
-    uint64 _r0, _r1, _r2, _r3;
-    sint64 total;
+    struct StateData
+    {
+        // registers, logger and other buffer
+        sint32 _i0, _i1, _i2, _i3;
+        sint64 _i64_0, _i64_1, _i64_2, _i64_3;
+        uint64 _r0, _r1, _r2, _r3;
+        sint64 total;
 
-    // Voting state
-    Array<QUTILPoll, QUTIL_MAX_POLL> polls;
-    Array<QUTILVoter, QUTIL_TOTAL_VOTERS> voters; // 1d array for all voters
-    Array<uint64, QUTIL_MAX_POLL> poll_ids;
-    Array<uint64, QUTIL_MAX_POLL> voter_counts; // tracks number of voters per poll
-    Array<Array<uint8, QUTIL_POLL_GITHUB_URL_MAX_SIZE>, QUTIL_MAX_POLL> poll_links; // github links for polls
-    uint64 current_poll_id;
-    uint64 new_polls_this_epoch;
+        // Voting state
+        Array<QUTILPoll, QUTIL_MAX_POLL> polls;
+        Array<QUTILVoter, QUTIL_TOTAL_VOTERS> voters; // 1d array for all voters
+        Array<uint64, QUTIL_MAX_POLL> poll_ids;
+        Array<uint64, QUTIL_MAX_POLL> voter_counts; // tracks number of voters per poll
+        Array<Array<uint8, QUTIL_POLL_GITHUB_URL_MAX_SIZE>, QUTIL_MAX_POLL> poll_links; // github links for polls
+        uint64 current_poll_id;
+        uint64 new_polls_this_epoch;
 
-    // DF function variables
-    m256i dfMiningSeed;
-    m256i dfCurrentState;
+        // DF function variables
+        m256i dfMiningSeed;
+        m256i dfCurrentState;
+    };
 
     // Get Qubic Balance
     struct get_qubic_balance_input {

--- a/test/testfiles/test_ok_cstyle_cast.h
+++ b/test/testfiles/test_ok_cstyle_cast.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int dummy = (int) someVar;
+    struct StateData
+    {
+        int dummy = (int) someVar;
+    };
 };

--- a/test/testfiles/test_ok_function_call.h
+++ b/test/testfiles/test_ok_function_call.h
@@ -3,5 +3,8 @@ using namespace QPI;
 struct TESTCON : public ContractBase
 {
 public:
-    int dummy = addOne(12);
+    struct StateData
+    {
+        int dummy = addOne(12);
+    };
 };

--- a/test/testfiles/test_ok_state_data.h
+++ b/test/testfiles/test_ok_state_data.h
@@ -1,10 +1,8 @@
 using namespace QPI;
-
 struct TESTCON : public ContractBase
 {
-public:
     struct StateData
     {
-        SomeStruct dummy = {1, 2, 3};
+        uint64 someVar;
     };
 };


### PR DESCRIPTION
State variables must now be placed inside a nested struct (e.g., StateData) rather than declared directly as members of the contract state struct. Updated all existing test files to comply with the new rule.

This is an update if https://github.com/qubic/core/pull/774 is merged.